### PR TITLE
Use ActionResult return type on action methods

### DIFF
--- a/IVRRecording.Web/Controllers/AgentController.cs
+++ b/IVRRecording.Web/Controllers/AgentController.cs
@@ -17,7 +17,7 @@ namespace IVRRecording.Web.Controllers
             _repository = repository;
         }
 
-        // GET: Recording
+        // GET: Agent
         public ActionResult Index()
         {
             var agents = _repository.All();
@@ -52,7 +52,7 @@ namespace IVRRecording.Web.Controllers
 
         // POST: Agent/ScreenCall
         [HttpPost]
-        public TwiMLResult ScreenCall(string from)
+        public ActionResult ScreenCall(string from)
         {
             var response = new TwilioResponse();
             var incomingCallMessage = "You have an incoming call from: " +
@@ -69,7 +69,7 @@ namespace IVRRecording.Web.Controllers
         }
 
         // GET: Agent/ConnectMessage
-        public TwiMLResult ConnectMessage()
+        public ActionResult ConnectMessage()
         {
             return TwiML(new TwilioResponse()
                 .Say("Connecting you to the extraterrestrial in distress"));
@@ -77,7 +77,7 @@ namespace IVRRecording.Web.Controllers
 
         // POST: Agent/Hangup
         [HttpPost]
-        public TwiMLResult Hangup()
+        public ActionResult Hangup()
         {
             var response = new TwilioResponse();
             response.Say("Thanks for your message. Goodbye",

--- a/IVRRecording.Web/Controllers/ExtensionController.cs
+++ b/IVRRecording.Web/Controllers/ExtensionController.cs
@@ -20,7 +20,7 @@ namespace IVRRecording.Web.Controllers
 
         // POST: Extension/Connect
         [HttpPost]
-        public TwiMLResult Connect(string digits)
+        public ActionResult Connect(string digits)
         {
             var extension = digits;
             var agent = FindAgentByExtension(extension);

--- a/IVRRecording.Web/Controllers/IVRController.cs
+++ b/IVRRecording.Web/Controllers/IVRController.cs
@@ -8,7 +8,7 @@ namespace IVRRecording.Web.Controllers
     {
         //POST: IVR/Welcome
         [HttpPost]
-        public TwiMLResult Welcome()
+        public ActionResult Welcome()
         {
             var response = new TwilioResponse();
             response.BeginGather(new {action = Url.Action("Show", "Menu"), numDigits = 1})

--- a/IVRRecording.Web/Controllers/MenuController.cs
+++ b/IVRRecording.Web/Controllers/MenuController.cs
@@ -10,7 +10,7 @@ namespace IVRRecording.Web.Controllers
     {
         // POST: Menu/Show
         [HttpPost]
-        public TwiMLResult Show(string digits)
+        public ActionResult Show(string digits)
         {
             var selectedOption = digits;
             var optionActions = new Dictionary<string, Func<TwiMLResult>>()


### PR DESCRIPTION
Favor `ActionResult` over `TwiMLResult` based on community preference style.

@devinrader, please have a look on this one, if you are ok with the changes left a LGTM or merge it. Thanks.